### PR TITLE
Add code coverage action

### DIFF
--- a/.github/workflows/code_coverage.yaml
+++ b/.github/workflows/code_coverage.yaml
@@ -24,7 +24,7 @@ jobs:
       
       # Installs dependencies
       - name: Install dependencies
-        run: apt-get update && apt-get install lcov
+        run: sudo apt-get update && sudo apt-get install -y lcov
       
       # Fetches proj dependencies from pub
       - name: Install dependencies


### PR DESCRIPTION
## Changes
Add a manually-triggered action to generate a code coverage report and upload it as an artifact. This makes it so that if we need to view code coverage information, we can trigger the action on the current commit on the main branch and click through the generated report in artifacts.

## Testing
- [x] No code changes