### PR TITLE
moving db folder to correct gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -43,6 +43,3 @@ app.*.map.json
 /android/app/debug
 /android/app/profile
 /android/app/release
-
-# Localstore database files
-/sample/

--- a/habit_task_tracker/.gitignore
+++ b/habit_task_tracker/.gitignore
@@ -43,3 +43,6 @@ app.*.map.json
 /android/app/debug
 /android/app/profile
 /android/app/release
+
+# Localstore database files
+/sample/


### PR DESCRIPTION
## Changes
localstore db file gitignore was in the root directory when it should be inside of /habit_task_tracker/.gitignore
moved last 2 lines for correct functionality 

## Related Issues
Closes #123

## Testing
- [ ] Unit tests pass
- [ ] Manual testing completed

## Screenshots
(if applicable)